### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:latest
 
 # Copy files
 WORKDIR /usr/src/app


### PR DESCRIPTION
when using node:carbon, the node version is too early for one of the dependencies, and therefore the docker image cannot be built